### PR TITLE
update links to dibbs-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ npm run dev
 yarn dev
 ```
 
-Open [http://localhost:3000/dibb-site](http://localhost:3000/dibb-site) with your browser to see the result.
+Open [http://localhost:3000/dibbs-site](http://localhost:3000/dibbs-site) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ npm run dev
 yarn dev
 ```
 
-Open [http://localhost:3000/phdi-site](http://localhost:3000/phdi-site) with your browser to see the result.
+Open [http://localhost:3000/dibb-site](http://localhost:3000/dibb-site) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.

--- a/components/NavbarUSWDS/NavbarUSWDS.js
+++ b/components/NavbarUSWDS/NavbarUSWDS.js
@@ -30,7 +30,7 @@ export default function Navbar({ }) {
                         <Title className='text-base-lightest'>
                             <Link href='/'>
                                 <a className="desktop:padding-1">
-                                    <span className={styles.navbarLogoText} href='/phdi-site'>
+                                    <span className={styles.navbarLogoText} href='/dibb-site'>
                                         Data Integration Building Blocks
                                     </span>
                                 </a>

--- a/components/NavbarUSWDS/NavbarUSWDS.js
+++ b/components/NavbarUSWDS/NavbarUSWDS.js
@@ -30,7 +30,7 @@ export default function Navbar({ }) {
                         <Title className='text-base-lightest'>
                             <Link href='/'>
                                 <a className="desktop:padding-1">
-                                    <span className={styles.navbarLogoText} href='/dibb-site'>
+                                    <span className={styles.navbarLogoText} href='/dibbs-site'>
                                         Data Integration Building Blocks
                                     </span>
                                 </a>

--- a/next.config.js
+++ b/next.config.js
@@ -8,8 +8,8 @@ const nextConfig = {
     loader: 'akamai',
     path: '/'
   },
-  basePath: "/phdi-site",
-  assetPrefix: '/phdi-site',
+  basePath: "/dibb-site",
+  assetPrefix: '/dibb-site',
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -8,8 +8,8 @@ const nextConfig = {
     loader: 'akamai',
     path: '/'
   },
-  basePath: "/dibb-site",
-  assetPrefix: '/dibb-site',
+  basePath: "/dibbs-site",
+  assetPrefix: '/dibbs-site',
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },


### PR DESCRIPTION
Resolves https://github.com/CDCgov/phdi/issues/940
Change the url to be `/dibbs-site` rather than `/phdi-site`

![image](https://github.com/CDCgov/dibbs-site/assets/10108172/fba451e3-ca05-4f51-a831-5b2c270e0b58)

