### PR TITLE
Update Public Health Data Strategy link to point to current version

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -36,7 +36,7 @@ export default function BuildingBlockInfo() {
                                 that they can take timely public health action. Our work
                                 contributes to&nbsp;
                                 <Link
-                                    href="https://www.cdc.gov/surveillance/pdfs/PRIME_1-sheet_single-page.pdf"
+                                    href="https://www.cdc.gov/ophdst/public-health-data-strategy/"
                                     target="_blank">
                                     CDC&apos;s public health data strategy
                                 </Link>.


### PR DESCRIPTION
The DIBBs site links to an old PRIME document. This pull request updates the page to link to the current Public Health Data Strategy located at https://www.cdc.gov/ophdst/public-health-data-strategy/