### PR TITLE
Set margin-x-auto for images on engage with us page 

### DIFF
--- a/pages/engage-with-us.js
+++ b/pages/engage-with-us.js
@@ -39,11 +39,11 @@ export default function GetInvolved() {
                             className="padding-x-205 padding-y-5 bg-primary-lighter desktop:radius-md desktop:padding-x-4">
                             <div
                                 className="text-center margin-bottom-105 desktop:display-none">
-                                <Image alt="" src={mobileGetInvolved1} />
+                                <Image alt="" className={"margin-x-auto"} src={mobileGetInvolved1} />
                             </div>
                             <div
                                 className="text-center margin-bottom-105 display-none desktop:display-block">
-                                <Image alt="" src={getInvolved1} />
+                                <Image alt="" className={"margin-x-auto"} src={getInvolved1} />
                             </div>
                             <h2
                                 className={`text-center text-accent-cool-darker margin-bottom-105 ${styles.partnerItemHeaders}`}
@@ -63,11 +63,11 @@ export default function GetInvolved() {
                             className="padding-x-205 desktop:padding-x-4 padding-y-5 bg-primary-lighter radius-md">
                             <div
                                 className="text-center margin-bottom-105 desktop:display-none">
-                                <Image alt="" src={mobileGetInvolved2} />
+                                <Image alt="" className={"margin-x-auto"} src={mobileGetInvolved2} />
                             </div>
                             <div
                                 className="text-center margin-bottom-105 display-none desktop:display-block">
-                                <Image alt="" src={getInvolved2} />
+                                <Image alt="" className={"margin-x-auto"} src={getInvolved2} />
                             </div>
                             <h2
                                 className={`text-center text-accent-cool-darker ${styles.partnerItemHeaders} margin-top-205 desktop:margin-top-0 margin-bottom-105`}


### PR DESCRIPTION
Currently, the images are not centered.


![image](https://github.com/CDCgov/dibbs-site/assets/10108172/ffa0964d-35f0-4a42-bfa4-6e107757e279)

![image](https://github.com/CDCgov/dibbs-site/assets/10108172/5ecce449-3c68-4519-aff7-2d9e1329077d)
