### PR TITLE
Incorporate classnames package and do some general cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,17 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript",
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "plugins": [
+    "react",
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,10 +7,7 @@
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
-  "plugins": [
-    "react",
-    "@typescript-eslint"
-  ],
+  "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "react/react-in-jsx-scope": "off"
   }

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v2
@@ -61,7 +61,7 @@ jobs:
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v9
         with:
-          configPath: "./lighthouserc.yml"
+          configPath: './lighthouserc.yml'
           uploadArtifacts: false # save results as an action artifacts
           temporaryPublicStorage: false # upload lighthouse report to the temporary storage
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,7 +20,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: true
 
 jobs:
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,8 @@
-{}
+{
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true,
+    "printWidth": 80,
+    "tabWidth": 2,
+    "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,8 @@
 {
-    "semi": true,
-    "trailingComma": "all",
-    "singleQuote": true,
-    "printWidth": 80,
-    "tabWidth": 2,
-    "plugins": ["prettier-plugin-tailwindcss"]
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/akamai-loader.js
+++ b/akamai-loader.js
@@ -1,4 +1,4 @@
-const normalizeSrc = (src) => (src[0] === "/" ? src.slice(1) : src);
+const normalizeSrc = (src) => (src[0] === '/' ? src.slice(1) : src);
 export default function akamaiLoader({ src, width, quality }) {
-  return "/" + normalizeSrc(src) + "?imwidth=" + width;
+  return '/' + normalizeSrc(src) + '?imwidth=' + width;
 }

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -1,6 +1,6 @@
 ci:
   collect:
-    staticDistDir: "./out"
+    staticDistDir: './out'
   assert:
     assertions:
       categories:accessibility: [error, { minScore: 1 }]

--- a/next.config.js
+++ b/next.config.js
@@ -1,20 +1,20 @@
-const path = require("path");
+const path = require('path');
 
 /**
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  output: "export",
+  output: 'export',
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    loader: "custom",
-    loaderFile: "./akamai-loader.js",
+    loader: 'custom',
+    loaderFile: './akamai-loader.js',
   },
-  basePath: "/dibbs-site",
-  assetPrefix: "/dibbs-site",
+  basePath: '/dibbs-site',
+  assetPrefix: '/dibbs-site',
   sassOptions: {
-    includePaths: [path.join(__dirname, "styles")],
+    includePaths: [path.join(__dirname, 'styles')],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@trussworks/react-uswds": "^9.1.0",
         "@uswds/uswds": "^3.9.0",
+        "classnames": "^2.5.1",
         "fs": "^0.0.1-security",
         "gray-matter": "^4.0.3",
         "next": "14.2.15",
@@ -23,13 +24,17 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
-        "eslint": "^8",
+        "eslint": "^8.57.1",
         "eslint-config-next": "14.2.15",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-react": "^7.37.2",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "postcss": "^8",
         "postcss-import": "^16.1.0",
-        "prettier": "3.3.3",
+        "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.8",
         "sass": "^1.79.5",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -704,6 +709,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1642,6 +1660,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2276,6 +2300,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2351,6 +2376,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -2527,18 +2565,50 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
-      "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
+      "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
         "array.prototype.flatmap": "^1.3.2",
         "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.0.19",
+        "es-iterator-helpers": "^1.1.0",
         "estraverse": "^5.3.0",
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
@@ -2755,6 +2825,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -5778,6 +5855,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5786,6 +5864,98 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.8.tgz",
+      "integrity": "sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/process": {
@@ -6746,6 +6916,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky",
-    "prettier": "prettier --write ."
+    "fmt": "prettier --write ."
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
@@ -16,6 +16,7 @@
   "dependencies": {
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.9.0",
+    "classnames": "^2.5.1",
     "fs": "^0.0.1-security",
     "gray-matter": "^4.0.3",
     "next": "14.2.15",
@@ -29,13 +30,17 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",
-    "eslint": "^8",
+    "eslint": "^8.57.1",
     "eslint-config-next": "14.2.15",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-react": "^7.37.2",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "postcss": "^8",
     "postcss-import": "^16.1.0",
-    "prettier": "3.3.3",
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.8",
     "sass": "^1.79.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -16,22 +16,23 @@ export default function Footer() {
 
   const testItemsMenu = [
     <Link
+      key="one"
       href="/"
       className={classNames('usa-nav__link', styles.homeNavItem)}
       onClick={onClick}
     >
       <span className={styles.navbarItemText}>Home</span>
     </Link>,
-    <NavigationLink href="/" onClick={onClick}>
+    <NavigationLink key="two" href="/" onClick={onClick}>
       Home
     </NavigationLink>,
-    <NavigationLink href="/our-products" onClick={onClick}>
+    <NavigationLink key="three" href="/our-products" onClick={onClick}>
       Our products
     </NavigationLink>,
-    <NavigationLink href="/case-studies" onClick={onClick}>
+    <NavigationLink key="four" href="/case-studies" onClick={onClick}>
       Case studies
     </NavigationLink>,
-    <NavigationLink href="/engage-with-us" onClick={onClick}>
+    <NavigationLink key="five" href="/engage-with-us" onClick={onClick}>
       Engage with us
     </NavigationLink>,
   ];

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,13 +1,13 @@
-"use client";
-import { Header, PrimaryNav } from "@trussworks/react-uswds";
-import Link from "next/link";
-import Image from "next/image";
-import React from "react";
-import styles from "../styles/Home.module.scss";
-import { NavigationLink } from "./Header";
+'use client';
+import { Header, PrimaryNav } from '@trussworks/react-uswds';
+import Link from 'next/link';
+import Image from 'next/image';
+import React from 'react';
+import styles from '../styles/Home.module.scss';
+import { NavigationLink } from './Header';
 
 export default function Footer() {
-  const basePath = "/dibbs-site";
+  const basePath = '/dibbs-site';
 
   const [expanded, setExpanded] = React.useState(false);
   const onClick = () => {
@@ -52,7 +52,7 @@ export default function Footer() {
                     width={200}
                     height={40}
                     alt=""
-                    className={"margin-x-0"}
+                    className={'margin-x-0'}
                     src={`${basePath}/images/CDC.svg`}
                   />
                 </a>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Header, PrimaryNav } from '@trussworks/react-uswds';
+import { PrimaryNav } from '@trussworks/react-uswds';
 import Link from 'next/link';
 import Image from 'next/image';
 import React from 'react';
@@ -38,7 +38,7 @@ export default function Footer() {
 
   return (
     <>
-      <Header basic={true} className="bg-background-teal">
+      <footer className="usa-header--basic bg-background-teal">
         <div className="usa-nav-container flex-vertical-center">
           <div className="usa-navbar">
             <div className="usa-logo">
@@ -69,7 +69,7 @@ export default function Footer() {
             onToggleMobileNav={onClick}
           />
         </div>
-      </Header>
+      </footer>
     </>
   );
 }

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,11 +4,11 @@ import Link from 'next/link';
 import Image from 'next/image';
 import React from 'react';
 import styles from '../styles/Home.module.scss';
-import { NavigationLink } from './Header';
+import { NavigationLink } from './NavigationLink';
+import classNames from 'classnames';
+import { basePath } from '../utils/constants';
 
 export default function Footer() {
-  const basePath = '/dibbs-site';
-
   const [expanded, setExpanded] = React.useState(false);
   const onClick = () => {
     if (window.innerWidth < 1024) setExpanded((prvExpanded) => !prvExpanded);
@@ -17,22 +17,21 @@ export default function Footer() {
   const testItemsMenu = [
     <Link
       href="/"
-      key="one"
-      className={`usa-nav__link ${styles.homeNavItem}`}
+      className={classNames('usa-nav__link', styles.homeNavItem)}
       onClick={onClick}
     >
       <span className={styles.navbarItemText}>Home</span>
     </Link>,
-    <NavigationLink key="two" href={`/`} onClick={onClick}>
+    <NavigationLink href="/" onClick={onClick}>
       Home
     </NavigationLink>,
-    <NavigationLink key="two" href={`/our-products`} onClick={onClick}>
+    <NavigationLink href="/our-products" onClick={onClick}>
       Our products
     </NavigationLink>,
-    <NavigationLink key="two" href={`/our-products`} onClick={onClick}>
+    <NavigationLink href="/case-studies" onClick={onClick}>
       Case studies
     </NavigationLink>,
-    <NavigationLink key="three" href={`/engage-with-us`} onClick={onClick}>
+    <NavigationLink href="/engage-with-us" onClick={onClick}>
       Engage with us
     </NavigationLink>,
   ];
@@ -45,14 +44,16 @@ export default function Footer() {
             <div className="usa-logo">
               <em className="usa-logo__text">
                 <a href="http://cdc.gov" title="<Project title>">
-                  <span className={`${styles.navbarLogoText} sr-only`}>
+                  <span
+                    className={classNames('sr-only', styles.navbarLogoText)}
+                  >
                     CDC US center for disease control and prevention
                   </span>
                   <Image
                     width={200}
                     height={40}
                     alt=""
-                    className={'margin-x-0'}
+                    className="margin-x-0"
                     src={`${basePath}/images/CDC.svg`}
                   />
                 </a>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,32 +1,26 @@
 'use client';
-import { Header, PrimaryNav } from '@trussworks/react-uswds';
-import Link from 'next/link';
+import { Header as USWDSHeader, PrimaryNav } from '@trussworks/react-uswds';
 import Image from 'next/image';
-import { usePathname } from 'next/navigation';
 import React from 'react';
 import styles from '../styles/Home.module.scss';
-import { LinkProps } from 'next/link';
+import classNames from 'classnames';
+import { basePath } from '../utils/constants';
+import { NavigationLink } from './NavigationLink';
 
-interface NavigationLinkProps extends Pick<LinkProps, 'href' | 'onClick'> {
-  children: React.ReactNode;
-}
-
-export default function Navbar() {
-  const basePath = '/dibbs-site';
-
+export default function Header() {
   const [expanded, setExpanded] = React.useState(false);
   const onClick = () => {
     if (window.innerWidth < 1024) setExpanded((prvExpanded) => !prvExpanded);
   };
 
   const testItemsMenu = [
-    <NavigationLink key="two" href="/our-products" onClick={onClick}>
+    <NavigationLink href="/our-products" onClick={onClick}>
       Our products
     </NavigationLink>,
-    <NavigationLink key="two" href="/case-studies" onClick={onClick}>
+    <NavigationLink href="/case-studies" onClick={onClick}>
       Case studies
     </NavigationLink>,
-    <NavigationLink key="three" href="/engage-with-us" onClick={onClick}>
+    <NavigationLink href="/engage-with-us" onClick={onClick}>
       Engage with us
     </NavigationLink>,
   ];
@@ -37,20 +31,22 @@ export default function Navbar() {
         Skip to main content
       </a>
 
-      <Header basic={true} className="bg-background-teal">
+      <USWDSHeader basic={true} className="bg-background-teal">
         <div className="usa-nav-container flex-vertical-center">
           <div className="usa-navbar">
             <div className="usa-logo">
               <em className="usa-logo__text">
                 <a href={`${basePath}/`} title="<Project title>">
-                  <span className={`${styles.navbarLogoText} sr-only`}>
+                  <span
+                    className={classNames('sr-only', styles.navbarLogoText)}
+                  >
                     Data Integration Building Blocks
                   </span>
                   <Image
                     width={200}
                     height={40}
                     alt=""
-                    className={'margin-x-0'}
+                    className="margin-x-0"
                     src={`${basePath}/images/dibbs-logo.svg`}
                   />
                 </a>
@@ -66,27 +62,7 @@ export default function Navbar() {
             onToggleMobileNav={onClick}
           />
         </div>
-      </Header>
+      </USWDSHeader>
     </>
-  );
-}
-
-export function NavigationLink({
-  href,
-  children,
-  onClick,
-}: NavigationLinkProps) {
-  const pathname = usePathname(); // Use usePathname hook to get the current path
-  const isActive = pathname === href;
-  return (
-    <Link href={href} passHref className={`usa-nav__link`} onClick={onClick}>
-      <span
-        className={
-          (isActive && 'navbar-item-active') + ' ' + styles.navbarItemText
-        }
-      >
-        {children}
-      </span>
-    </Link>
   );
 }

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,18 +1,18 @@
-"use client";
-import { Header, PrimaryNav } from "@trussworks/react-uswds";
-import Link from "next/link";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
-import React from "react";
-import styles from "../styles/Home.module.scss";
-import { LinkProps } from "next/link";
+'use client';
+import { Header, PrimaryNav } from '@trussworks/react-uswds';
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import React from 'react';
+import styles from '../styles/Home.module.scss';
+import { LinkProps } from 'next/link';
 
-interface NavigationLinkProps extends Pick<LinkProps, "href" | "onClick"> {
+interface NavigationLinkProps extends Pick<LinkProps, 'href' | 'onClick'> {
   children: React.ReactNode;
 }
 
 export default function Navbar() {
-  const basePath = "/dibbs-site";
+  const basePath = '/dibbs-site';
 
   const [expanded, setExpanded] = React.useState(false);
   const onClick = () => {
@@ -50,7 +50,7 @@ export default function Navbar() {
                     width={200}
                     height={40}
                     alt=""
-                    className={"margin-x-0"}
+                    className={'margin-x-0'}
                     src={`${basePath}/images/dibbs-logo.svg`}
                   />
                 </a>
@@ -82,7 +82,7 @@ export function NavigationLink({
     <Link href={href} passHref className={`usa-nav__link`} onClick={onClick}>
       <span
         className={
-          (isActive && "navbar-item-active") + " " + styles.navbarItemText
+          (isActive && 'navbar-item-active') + ' ' + styles.navbarItemText
         }
       >
         {children}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -36,7 +36,7 @@ export default function Navbar() {
       <a className="usa-skipnav" href="#main-content">
         Skip to main content
       </a>
-      <div className={`usa-overlay ${expanded ? "is-visible" : ""}`}></div>
+
       <Header basic={true} className="bg-background-teal">
         <div className="usa-nav-container flex-vertical-center">
           <div className="usa-navbar">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -14,13 +14,13 @@ export default function Header() {
   };
 
   const testItemsMenu = [
-    <NavigationLink href="/our-products" onClick={onClick}>
+    <NavigationLink key="one" href="/our-products" onClick={onClick}>
       Our products
     </NavigationLink>,
-    <NavigationLink href="/case-studies" onClick={onClick}>
+    <NavigationLink key="two" href="/case-studies" onClick={onClick}>
       Case studies
     </NavigationLink>,
-    <NavigationLink href="/engage-with-us" onClick={onClick}>
+    <NavigationLink key="three" href="/engage-with-us" onClick={onClick}>
       Engage with us
     </NavigationLink>,
   ];

--- a/src/app/components/MarkdownComponent.tsx
+++ b/src/app/components/MarkdownComponent.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactMarkdown from "react-markdown";
-import { getMarkdownContent } from "../utils/markdown";
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { getMarkdownContent } from '../utils/markdown';
 
 export default async function MarkdownContent(fileName: string) {
   const markdownContent = await getMarkdownContent(fileName);

--- a/src/app/components/NavigationLink.tsx
+++ b/src/app/components/NavigationLink.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+import Link, { LinkProps } from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from '../styles/Home.module.scss';
+
+interface NavigationLinkProps extends Pick<LinkProps, 'href' | 'onClick'> {
+  children: React.ReactNode;
+}
+
+export function NavigationLink({
+  href,
+  children,
+  onClick,
+}: NavigationLinkProps) {
+  const pathname = usePathname(); // Use usePathname hook to get the current path
+  const isActive = pathname === href;
+  return (
+    <Link href={href} passHref className="usa-nav__link" onClick={onClick}>
+      <span
+        className={classNames(styles.navbarItemText, {
+          'navbar-item-active': isActive,
+        })}
+      >
+        {children}
+      </span>
+    </Link>
+  );
+}

--- a/src/app/components/UsaBanner.tsx
+++ b/src/app/components/UsaBanner.tsx
@@ -11,13 +11,10 @@ import {
   MediaBlockBody,
   Icon,
 } from '@trussworks/react-uswds';
+import { dotGovIcon, flagImg, httpsIcon } from '../utils/constants';
 
 export default function USABanner() {
-  const basePath: string = '/dibbs-site';
   const [isOpen, setIsOpen] = useState(false);
-  const flagImg: string = `${basePath}/images/us-flag.png`;
-  const dotGovIcon: string = `${basePath}/images/us-gov-icon.svg`;
-  const httpsIcon: string = `${basePath}/images/https-icon.svg`;
   return (
     <Banner aria-label="Official website of the state department of something specific">
       <BannerHeader

--- a/src/app/components/UsaBanner.tsx
+++ b/src/app/components/UsaBanner.tsx
@@ -1,5 +1,5 @@
-"use client";
-import React, { useState } from "react";
+'use client';
+import React, { useState } from 'react';
 import {
   Banner,
   BannerHeader,
@@ -10,10 +10,10 @@ import {
   BannerFlag,
   MediaBlockBody,
   Icon,
-} from "@trussworks/react-uswds";
+} from '@trussworks/react-uswds';
 
 export default function USABanner() {
-  const basePath: string = "/dibbs-site";
+  const basePath: string = '/dibbs-site';
   const [isOpen, setIsOpen] = useState(false);
   const flagImg: string = `${basePath}/images/us-flag.png`;
   const dotGovIcon: string = `${basePath}/images/us-gov-icon.svg`;
@@ -53,10 +53,10 @@ export default function USABanner() {
             <MediaBlockBody>
               <p>
                 <strong>Secure .gov websites use HTTPS</strong>
-                <br />A{" "}
+                <br />A{' '}
                 <strong>
                   lock (<Icon.Lock aria-label="Locked padlock icon" />)
-                </strong>{" "}
+                </strong>{' '}
                 or <strong>https://</strong> means you&apos;ve safely connected
                 to the .gov website. Share sensitive information only on
                 official, secure websites.

--- a/src/app/components/UsaBanner.tsx
+++ b/src/app/components/UsaBanner.tsx
@@ -11,10 +11,15 @@ import {
   MediaBlockBody,
   Icon,
 } from '@trussworks/react-uswds';
-import { dotGovIcon, flagImg, httpsIcon } from '../utils/constants';
+import { basePath } from '../utils/constants';
 
 export default function USABanner() {
   const [isOpen, setIsOpen] = useState(false);
+
+  const flagImg = `${basePath}/images/us-flag.png`;
+  const dotGovIcon = `${basePath}/images/us-gov-icon.svg`;
+  const httpsIcon = `${basePath}/images/https-icon.svg`;
+
   return (
     <Banner aria-label="Official website of the state department of something specific">
       <BannerHeader

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import "@trussworks/react-uswds/lib/uswds.css";
-@import "@trussworks/react-uswds/lib/index.css";
+@import '@trussworks/react-uswds/lib/uswds.css';
+@import '@trussworks/react-uswds/lib/index.css';
 
 :root {
   --background: #ffffff;
@@ -69,7 +69,7 @@ h1 {
 }
 
 h1 {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   font-size: 40px;
   font-weight: 700;
   line-height: 50.28px;
@@ -78,7 +78,7 @@ h1 {
 
 h2 {
   color: #224a58;
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   font-size: 2rem;
   font-style: normal;
   font-weight: 700;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from "next";
-import "./globals.css";
-import Script from "next/script";
-import Navbar from "./components/Header";
-import Footer from "./components/Footer";
-import USABanner from "./components/UsaBanner";
+import type { Metadata } from 'next';
+import './globals.css';
+import Script from 'next/script';
+import Navbar from './components/Header';
+import Footer from './components/Footer';
+import USABanner from './components/UsaBanner';
 
 export const metadata: Metadata = {
-  title: "DIBBS Site",
+  title: 'DIBBS Site',
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import Script from 'next/script';
-import Navbar from './components/Header';
+import Header from './components/Header';
 import Footer from './components/Footer';
 import USABanner from './components/UsaBanner';
+import { basePath } from './utils/constants';
 
 export const metadata: Metadata = {
   title: 'DIBBS Site',
+  icons: {
+    icon: `${basePath}/app/favicon.ico`,
+  },
 };
 
 export default function RootLayout({
@@ -16,11 +20,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head></head>
       <body>
         <USABanner />
         <div>
-          <Navbar />
+          <Header />
           <main id="main-content">{children}</main>
           <Footer />
         </div>

--- a/src/app/our-products/page.tsx
+++ b/src/app/our-products/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from 'next/link';
 
 export default function ProductDetail() {
   return (
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Our Products</h1>
       <ul>
         <li>
-          <Link href={"/"}>Home</Link>
+          <Link href={'/'}>Home</Link>
         </li>
         <li>
-          <Link href={"/our-products"}>Our products</Link>
+          <Link href={'/our-products'}>Our products</Link>
         </li>
         <li>
-          <Link href={"/product-detail"}>Product detail</Link>
+          <Link href={'/product-detail'}>Product detail</Link>
         </li>
         <li>
-          <Link href={"/resources"}>Resources</Link>
+          <Link href={'/resources'}>Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/our-products/page.tsx
+++ b/src/app/our-products/page.tsx
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Our Products</h1>
       <ul>
         <li>
-          <Link href={'/'}>Home</Link>
+          <Link href="/">Home</Link>
         </li>
         <li>
-          <Link href={'/our-products'}>Our products</Link>
+          <Link href="/our-products">Our products</Link>
         </li>
         <li>
-          <Link href={'/product-detail'}>Product detail</Link>
+          <Link href="/product-detail">Product detail</Link>
         </li>
         <li>
-          <Link href={'/resources'}>Resources</Link>
+          <Link href="/resources">Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,9 @@
 import MarkdownContent from './components/MarkdownComponent';
 import { Grid } from '@trussworks/react-uswds';
 import Image from 'next/image';
+import { basePath } from './utils/constants';
 
 export default async function Home() {
-  const basePath = '/dibbs-site';
-
   return (
     <>
       <section className="usa-graphic-list usa-section usa-section--light-blue">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,15 @@
-import MarkdownContent from "./components/MarkdownComponent";
-import { Grid } from "@trussworks/react-uswds";
-import Image from "next/image";
+import MarkdownContent from './components/MarkdownComponent';
+import { Grid } from '@trussworks/react-uswds';
+import Image from 'next/image';
 
 export default async function Home() {
-  const basePath = "/dibbs-site";
+  const basePath = '/dibbs-site';
 
   return (
     <>
       <section className="usa-graphic-list usa-section usa-section--light-blue">
         <div className="grid-container">
-          {MarkdownContent("homepage/section_1.md")}
+          {MarkdownContent('homepage/section_1.md')}
         </div>
       </section>
       <section className="usa-section">
@@ -23,14 +23,14 @@ export default async function Home() {
                 alt="Placeholder"
               />
             </Grid>
-            <Grid col={7}>{MarkdownContent("homepage/section_2.md")}</Grid>
+            <Grid col={7}>{MarkdownContent('homepage/section_2.md')}</Grid>
           </Grid>
         </div>
       </section>
       <section className="usa-section">
         <div className="grid-container">
           <Grid row>
-            <Grid col={5}>{MarkdownContent("homepage/section_3.md")}</Grid>
+            <Grid col={5}>{MarkdownContent('homepage/section_3.md')}</Grid>
             <Grid col={7} className="flex-vertical-center padding-x-1">
               <Image
                 src={`${basePath}/images/placeholder.png`}
@@ -46,7 +46,7 @@ export default async function Home() {
         <div className="grid-container">
           <Grid row>
             <Grid col={12} className="flex-center">
-              {MarkdownContent("homepage/section_4.md")}
+              {MarkdownContent('homepage/section_4.md')}
             </Grid>
           </Grid>
         </div>

--- a/src/app/product-detail/page.tsx
+++ b/src/app/product-detail/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from 'next/link';
 
 export default function ProductDetail() {
   return (
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Product Detail</h1>
       <ul>
         <li>
-          <Link href={"/"}>Home</Link>
+          <Link href={'/'}>Home</Link>
         </li>
         <li>
-          <Link href={"/our-products"}>Our products</Link>
+          <Link href={'/our-products'}>Our products</Link>
         </li>
         <li>
-          <Link href={"/product-detail"}>Product detail</Link>
+          <Link href={'/product-detail'}>Product detail</Link>
         </li>
         <li>
-          <Link href={"/resources"}>Resources</Link>
+          <Link href={'/resources'}>Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/product-detail/page.tsx
+++ b/src/app/product-detail/page.tsx
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Product Detail</h1>
       <ul>
         <li>
-          <Link href={'/'}>Home</Link>
+          <Link href="/">Home</Link>
         </li>
         <li>
-          <Link href={'/our-products'}>Our products</Link>
+          <Link href="/our-products">Our products</Link>
         </li>
         <li>
-          <Link href={'/product-detail'}>Product detail</Link>
+          <Link href="/product-detail">Product detail</Link>
         </li>
         <li>
-          <Link href={'/resources'}>Resources</Link>
+          <Link href="/resources">Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Resources</h1>
       <ul>
         <li>
-          <Link href={'/'}>Home</Link>
+          <Link href="/">Home</Link>
         </li>
         <li>
-          <Link href={'/our-products'}>Our products</Link>
+          <Link href="/our-products">Our products</Link>
         </li>
         <li>
-          <Link href={'/product-detail'}>Product detail</Link>
+          <Link href="/product-detail">Product detail</Link>
         </li>
         <li>
-          <Link href={'/resources'}>Resources</Link>
+          <Link href="/resources">Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from 'next/link';
 
 export default function ProductDetail() {
   return (
@@ -6,16 +6,16 @@ export default function ProductDetail() {
       <h1>Resources</h1>
       <ul>
         <li>
-          <Link href={"/"}>Home</Link>
+          <Link href={'/'}>Home</Link>
         </li>
         <li>
-          <Link href={"/our-products"}>Our products</Link>
+          <Link href={'/our-products'}>Our products</Link>
         </li>
         <li>
-          <Link href={"/product-detail"}>Product detail</Link>
+          <Link href={'/product-detail'}>Product detail</Link>
         </li>
         <li>
-          <Link href={"/resources"}>Resources</Link>
+          <Link href={'/resources'}>Resources</Link>
         </li>
       </ul>
     </div>

--- a/src/app/styles/Home.module.scss
+++ b/src/app/styles/Home.module.scss
@@ -70,7 +70,7 @@
   }
 
   .partnerItemHeaders {
-    font-family: "Public Sans", sans-serif;
+    font-family: 'Public Sans', sans-serif;
     font-weight: 700;
     font-size: 32px;
     line-height: 38px;
@@ -121,7 +121,7 @@
   }
 
   .partnerItemHeaders {
-    font-family: "Public Sans", sans-serif;
+    font-family: 'Public Sans', sans-serif;
     font-weight: 400;
     font-size: 22px;
     line-height: 26px;

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,6 +1,3 @@
 const basePath = '/dibbs-site';
-const flagImg = `${basePath}/images/us-flag.png`;
-const dotGovIcon = `${basePath}/images/us-gov-icon.svg`;
-const httpsIcon = `${basePath}/images/https-icon.svg`;
 
-export { basePath, flagImg, dotGovIcon, httpsIcon };
+export { basePath };

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,0 +1,6 @@
+const basePath = '/dibbs-site';
+const flagImg = `${basePath}/images/us-flag.png`;
+const dotGovIcon = `${basePath}/images/us-gov-icon.svg`;
+const httpsIcon = `${basePath}/images/https-icon.svg`;
+
+export { basePath, flagImg, dotGovIcon, httpsIcon };

--- a/src/app/utils/markdown.ts
+++ b/src/app/utils/markdown.ts
@@ -1,10 +1,10 @@
-import * as fs from "fs";
-import * as path from "path";
-import matter from "gray-matter";
+import * as fs from 'fs';
+import * as path from 'path';
+import matter from 'gray-matter';
 
 export async function getMarkdownContent(fileName: string) {
-  const markdownFilePath = path.join(process.cwd(), "src/content", fileName);
-  const fileContents = fs.readFileSync(markdownFilePath, "utf8");
+  const markdownFilePath = path.join(process.cwd(), 'src/content', fileName);
+  const fileContents = fs.readFileSync(markdownFilePath, 'utf8');
   const { content } = matter(fileContents, undefined);
 
   return content;

--- a/src/app/utils/markdown.ts
+++ b/src/app/utils/markdown.ts
@@ -5,7 +5,7 @@ import matter from 'gray-matter';
 export async function getMarkdownContent(fileName: string) {
   const markdownFilePath = path.join(process.cwd(), 'src/content', fileName);
   const fileContents = fs.readFileSync(markdownFilePath, 'utf8');
-  const { content } = matter(fileContents, undefined);
+  const { content } = matter(fileContents);
 
   return content;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,16 +1,16 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR does the following:

- Adds and makes use of `classNames` where appropriate
- Adds some reasonable defaults for `prettier` and `eslint`
  - A couple of new `devDependencies` were added for this 
- Formats all applicable files using the new `prettier` defaults
- Ensures the `Footer` component renders a `footer` element rather than another `header`
- Moves `NavigationLink` and its prop type into its own file
- Moved the heavily used `basePath` variable into its own `constants.ts` file
- Fixed an error where Next.js couldn't find the `favicon.ico`
- Some other minor cleanup 

## Testing

1. Run `npm i` to install the new packages
2. Start the project (restart might be needed)
3. Make sure everything generally still works and looks the same

If you happen to run into any issues, it might be worth trying to delete the `.next` folder and restarting your dev build.

## Discussion

The "reasonable defaults" felt like a good starting point to me but we can definitely adjust these over time if we think any of the ESLint rules aren't useful to us.