### PR TITLE
Add 'aria-current' to selected nav item

### DIFF
--- a/src/app/components/NavigationLink/NavigationLink.tsx
+++ b/src/app/components/NavigationLink/NavigationLink.tsx
@@ -12,9 +12,15 @@ export function NavigationLink({
   onClick,
 }: NavigationLinkProps) {
   const pathname = usePathname();
-  const isActive = pathname === href;
+  const isActive = pathname.includes(href.toString());
+
   return (
-    <Link href={href} passHref onClick={onClick}>
+    <Link
+      href={href}
+      passHref
+      onClick={onClick}
+      {...(isActive ? { 'aria-current': 'page' } : {})}
+    >
       <span
         className={classNames('text-white', {
           underline: isActive,


### PR DESCRIPTION
This PR ensures that `aria-current="page"` is added to the link element of the page we're currently looking at. Additionally, I've slightly modified the `NavigationLink` so that navigating to child pages will allow the  top-level parent page's nav link to remain underlined.

For example, navigating to the `/products/ecr-viewer` page will keep the `Our products` link underlined in the nav.