### PR TITLE
Update workspace settings to show linting warnings/errors in editor

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "eslint.validate": [ "javascript", "javascriptreact", "html", "typescriptreact" ],
   "cSpell.words": ["USWDS"]
 }

--- a/src/app/hooks/useHeroInit.ts
+++ b/src/app/hooks/useHeroInit.ts
@@ -19,5 +19,5 @@ export function useHeroInit({ header, subheader, heroClass }: HeroInitProps) {
       heroClass,
       pathname,
     });
-  }, [setHeroContent, header, subheader, heroClass]);
+  }, [setHeroContent, header, subheader, heroClass, pathname]);
 }


### PR DESCRIPTION
This PR adjusts the shared VS Code `settings.json` so that ESLint warnings and errors will now appear within the VS Code editor when using the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).

Here's an example (which I've fixed in this PR):
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/8524aa32-50f0-4588-8ce2-982a10c06891">
