### PR TITLE
Style "engage with us" page to match design

### DIFF
--- a/src/app/components/RoundedBackground/RoundedBackground.tsx
+++ b/src/app/components/RoundedBackground/RoundedBackground.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+
+interface RoundedBackgroundProps extends React.ComponentProps<'div'> {
+  children: React.ReactNode;
+}
+
+export const RoundedBackground = ({
+  children,
+  className,
+  ...props
+}: RoundedBackgroundProps) => {
+  return (
+    <div
+      {...props}
+      className={classNames(
+        'rounded-br-[2.5rem] rounded-tl-[2.5rem] border-2 border-[#82b4c9] bg-white/50',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -22,13 +22,19 @@ export default function EngageWithUs() {
     <ContentContainer>
       <div className="flex flex-col gap-10">
         <Alert />
-        <div className="grid grid-cols-1 justify-items-center gap-[3.75rem] lg:grid-cols-2 lg:justify-items-start">
-          <div>
-            <Left />
-          </div>
-          <div>
-            <Right />
-          </div>
+        <div className="lg:pl-5">
+          <h2>Contact us</h2>
+          <p className="text-base font-normal leading-relaxed text-[#224a58]">
+            Fill out the form below to get in touch with us
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 justify-items-start gap-[3.75rem] lg:grid-cols-2">
+        <div className="min-w-full">
+          <Left />
+        </div>
+        <div className="justify-self-center lg:justify-self-start">
+          <Right />
         </div>
       </div>
     </ContentContainer>
@@ -38,13 +44,9 @@ export default function EngageWithUs() {
 function Left() {
   return (
     <div className="lg:pl-5">
-      <h2>Contact us</h2>
-      <p className="text-base font-normal leading-relaxed text-[#224a58]">
-        Fill out the form below to get in touch with us
-      </p>
       <Form
         onSubmit={() => {}}
-        className="align-start flex flex-col gap-2 lg:min-w-[31.25rem]"
+        className="align-start flex min-w-full flex-col gap-5 lg:min-w-[31.25rem]"
       >
         <div className="flex flex-col gap-5 lg:max-w-[70%]">
           <div>
@@ -88,6 +90,7 @@ function Left() {
             Type of inquiry
           </Label>
           <ComboBox
+            className="!min-w-full"
             id="inquiry"
             name="inquiry"
             options={[
@@ -100,14 +103,15 @@ function Left() {
             onChange={() => {}}
           />
         </div>
-
-        <Label
-          htmlFor="message"
-          className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
-        >
-          Message
-        </Label>
-        <Textarea id="message" name="message" className="resize-none" />
+        <div>
+          <Label
+            htmlFor="message"
+            className="m-0 self-stretch text-base font-bold leading-relaxed text-[#224a58]"
+          >
+            Message
+          </Label>
+          <Textarea id="message" name="message" className="resize-none" />
+        </div>
       </Form>
       <Button
         type="submit"
@@ -143,17 +147,17 @@ const RoundedBackground = ({
 
 function Right() {
   return (
-    <RoundedBackground className="p-10">
-      <div className="ml-2 flex flex-col gap-3 xl:min-w-[35.25rem]">
+    <RoundedBackground className="p-6 xl:p-10">
+      <div className="ml-2 flex flex-col gap-3">
         <p className="font-['Public Sans'] m-0 p-0 text-base font-light uppercase leading-normal text-[#2e6276]">
           Customer Testimonial
         </p>
-        <p className="font-['Public Sans'] m-0 max-w-[28rem] p-0 text-[1rem] font-bold italic leading-[2rem] text-[#224a58] lg:text-[1.38rem]">
-          "Our epidemiologists waste 80% of their time cleaning data and can't
+        <p className="font-['Public Sans'] m-0 max-w-[28rem] p-0 text-[1rem] font-bold italic leading-[2rem] text-[#224a58] xl:text-[1.38rem]">
+          “Our epidemiologists waste 80% of their time cleaning data and can't
           do useful analysis. The end goal of DIBBs infrastructure is to free up
-          that 80% of their time to do actual public health work."
+          that 80% of their time to do actual public health work.”
         </p>
-        <p className="m-0 text-nowrap p-0 text-[1rem] font-light leading-[2rem] text-[#224a58] lg:text-base xl:min-w-full">
+        <p className="m-0 p-0 text-[1rem] font-light leading-normal text-[#224a58] lg:text-nowrap lg:text-base xl:min-w-full">
           - Public Health Official, Virginia Department of Health
         </p>
       </div>

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -21,7 +21,7 @@ const EngageWithUs = () => {
   return (
     <ContentContainer classes="sm:pt-10">
       <div className="flex flex-col gap-10">
-        <Alert />
+        <ConsultationAlert />
         <div className="lg:pl-5">
           <h2>Contact us</h2>
           <p className="text-base font-normal leading-relaxed text-[#224a58]">
@@ -31,17 +31,17 @@ const EngageWithUs = () => {
       </div>
       <div className="grid grid-cols-1 justify-items-start gap-[3.75rem] lg:grid-cols-2">
         <div className="min-w-full">
-          <Left />
+          <ContactForm />
         </div>
         <div className="justify-self-center lg:justify-self-start">
-          <Right />
+          <CustomerTestimonial />
         </div>
       </div>
     </ContentContainer>
   );
 };
 
-const Left = () => {
+const ContactForm = () => {
   return (
     <div className="lg:pl-5">
       <Form
@@ -123,7 +123,7 @@ const Left = () => {
   );
 };
 
-const Right = () => {
+const CustomerTestimonial = () => {
   return (
     <RoundedBackground className="p-6 xl:p-10">
       <div className="ml-2 flex flex-col gap-3">
@@ -143,7 +143,7 @@ const Right = () => {
   );
 };
 
-const Alert = () => {
+const ConsultationAlert = () => {
   return (
     <div className="usa-alert usa-alert--info usa-alert--no-icon border-l-[#00BDE3] lg:max-w-[80%]">
       <div className="usa-alert__body !bg-[#2E6276]">

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@trussworks/react-uswds';
 import { ContentContainer } from '../components/ContentContainer/ContentContainer';
 import { useHeroInit } from '../hooks/useHeroInit';
-import classNames from 'classnames';
+import { RoundedBackground } from '../components/RoundedBackground/RoundedBackground';
 
 const EngageWithUs = () => {
   useHeroInit({
@@ -39,7 +39,7 @@ const EngageWithUs = () => {
       </div>
     </ContentContainer>
   );
-}
+};
 
 const Left = () => {
   return (
@@ -119,28 +119,6 @@ const Left = () => {
       >
         Send inquiry
       </Button>
-    </div>
-  );
-}
-
-interface RoundedBackgroundProps extends React.ComponentProps<'div'> {
-  children: React.ReactNode;
-}
-
-const RoundedBackground = ({
-  children,
-  className,
-  ...props
-}: RoundedBackgroundProps) => {
-  return (
-    <div
-      {...props}
-      className={classNames(
-        'rounded-br-[2.5rem] rounded-tl-[2.5rem] border-2 border-[#82b4c9] bg-white/50',
-        className,
-      )}
-    >
-      {children}
     </div>
   );
 };

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -130,7 +130,7 @@ const Right = () => {
         <p className="font-['Public Sans'] m-0 p-0 text-base font-light uppercase leading-normal text-[#2e6276]">
           Customer Testimonial
         </p>
-        <p className="font-['Public Sans'] m-0 max-w-[28rem] p-0 text-[1rem] font-bold italic leading-[2rem] text-[#224a58] xl:text-[1.38rem]">
+        <p className="font-['Public Sans'] m-0 max-w-[28rem] p-0 text-[1rem] font-bold leading-[2rem] text-[#224a58] xl:text-[1.38rem]">
           “Our epidemiologists waste 80% of their time cleaning data and can't
           do useful analysis. The end goal of DIBBs infrastructure is to free up
           that 80% of their time to do actual public health work.”

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -11,7 +11,7 @@ import { ContentContainer } from '../components/ContentContainer/ContentContaine
 import { useHeroInit } from '../hooks/useHeroInit';
 import classNames from 'classnames';
 
-export default function EngageWithUs() {
+const EngageWithUs = () => {
   useHeroInit({
     header: `Get started with DIBBs products`,
     subheader: `Learn how your jurisdiction can start working with the DIBBs team.`,
@@ -41,7 +41,7 @@ export default function EngageWithUs() {
   );
 }
 
-function Left() {
+const Left = () => {
   return (
     <div className="lg:pl-5">
       <Form
@@ -145,7 +145,7 @@ const RoundedBackground = ({
   );
 };
 
-function Right() {
+const Right = () => {
   return (
     <RoundedBackground className="p-6 xl:p-10">
       <div className="ml-2 flex flex-col gap-3">
@@ -163,7 +163,7 @@ function Right() {
       </div>
     </RoundedBackground>
   );
-}
+};
 
 const Alert = () => {
   return (
@@ -180,3 +180,5 @@ const Alert = () => {
     </div>
   );
 };
+
+export default EngageWithUs;

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -25,7 +25,7 @@ const EngageWithUs = () => {
         <div className="lg:pl-5">
           <h2>Contact us</h2>
           <p className="text-base font-normal leading-relaxed text-[#224a58]">
-            Fill out the form below to get in touch with us
+            Fill out the form below to get in touch with us.
           </p>
         </div>
       </div>

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -19,7 +19,7 @@ const EngageWithUs = () => {
   });
 
   return (
-    <ContentContainer>
+    <ContentContainer classes="sm:pt-10">
       <div className="flex flex-col gap-10">
         <Alert />
         <div className="lg:pl-5">

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@trussworks/react-uswds';
 import { ContentContainer } from '../components/ContentContainer/ContentContainer';
 import { useHeroInit } from '../hooks/useHeroInit';
+import classNames from 'classnames';
 
 export default function EngageWithUs() {
   useHeroInit({
@@ -18,9 +19,10 @@ export default function EngageWithUs() {
   });
 
   return (
-    <div>
-      <ContentContainer>
-        <div className="grid grid-cols-1 justify-items-center gap-6 lg:grid-cols-2 lg:justify-items-start">
+    <ContentContainer>
+      <div className="flex flex-col gap-10">
+        <Alert />
+        <div className="grid grid-cols-1 justify-items-center gap-[3.75rem] lg:grid-cols-2 lg:justify-items-start">
           <div>
             <Left />
           </div>
@@ -28,52 +30,60 @@ export default function EngageWithUs() {
             <Right />
           </div>
         </div>
-      </ContentContainer>
-    </div>
+      </div>
+    </ContentContainer>
   );
 }
 
 function Left() {
   return (
-    <>
+    <div className="lg:pl-5">
       <h2>Contact us</h2>
       <p className="text-base font-normal leading-relaxed text-[#224a58]">
         Fill out the form below to get in touch with us
       </p>
       <Form
         onSubmit={() => {}}
-        className="align-start flex flex-col gap-y-2 lg:min-w-[31.25rem]"
+        className="align-start flex flex-col gap-2 lg:min-w-[31.25rem]"
       >
-        <div className="lg:max-w-[70%]">
-          <Label
-            htmlFor="name"
-            className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
-          >
-            Name
-          </Label>
-          <TextInput
-            id="name"
-            name="name"
-            type="text"
-            className="lg:max-w-[2rem]"
-          />
-          <Label
-            htmlFor="email"
-            className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
-          >
-            Email Address
-          </Label>
-          <TextInput id="email" name="email" type="email" />
-          <Label
-            htmlFor="organization"
-            className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
-          >
-            Organization
-          </Label>
-          <TextInput id="organization" name="organization" type="text" />
+        <div className="flex flex-col gap-5 lg:max-w-[70%]">
+          <div>
+            <Label
+              htmlFor="name"
+              className="m-0 self-stretch text-base font-bold leading-relaxed text-[#224a58]"
+            >
+              Name
+            </Label>
+            <TextInput
+              id="name"
+              name="name"
+              type="text"
+              className="lg:max-w-[2rem]"
+            />
+          </div>
+          <div>
+            <Label
+              htmlFor="email"
+              className="m-0 self-stretch text-base font-bold leading-relaxed text-[#224a58]"
+            >
+              Email Address
+            </Label>
+            <TextInput id="email" name="email" type="email" />
+          </div>
+          <div>
+            <Label
+              htmlFor="organization"
+              className="m-0 self-stretch text-base font-bold leading-relaxed text-[#224a58]"
+            >
+              Organization
+            </Label>
+            <TextInput id="organization" name="organization" type="text" />
+          </div>
+        </div>
+        <div className="lg:max-w-[85%]">
           <Label
             htmlFor="inquiry"
-            className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
+            className="m-0 self-stretch text-base font-bold leading-relaxed text-[#224a58]"
           >
             Type of inquiry
           </Label>
@@ -90,6 +100,7 @@ function Left() {
             onChange={() => {}}
           />
         </div>
+
         <Label
           htmlFor="message"
           className="self-stretch text-base font-bold leading-relaxed text-[#224a58]"
@@ -104,35 +115,64 @@ function Left() {
       >
         Send inquiry
       </Button>
-    </>
+    </div>
   );
 }
 
+interface RoundedBackgroundProps extends React.ComponentProps<'div'> {
+  children: React.ReactNode;
+}
+
+const RoundedBackground = ({
+  children,
+  className,
+  ...props
+}: RoundedBackgroundProps) => {
+  return (
+    <div
+      {...props}
+      className={classNames(
+        'rounded-br-[2.5rem] rounded-tl-[2.5rem] border-2 border-[#82b4c9] bg-white/50',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
 function Right() {
   return (
-    <>
-      <div id="content" className="flex flex-col gap-10 pt-4">
-        <div className="border border-dashed bg-white p-4 text-center lg:p-[1.75rem]">
-          <p className="text-center text-[1.2rem] font-bold leading-[2rem] text-black xl:text-[1.40rem]">
-            All consultations with the DIBBs team are 100% free. There's no cost
-            to use our products beyond costs to host within your jurisdiction
-            should you choose to do so.
-          </p>
-        </div>
-        <div>
-          <div className="ml-2 flex flex-col gap-4 xl:min-w-[35.25rem]">
-            <p className="m-0 p-0 text-[1rem] font-bold italic leading-[2rem] text-[#224a58] xl:m-4 xl:text-[1.38rem]">
-              "Our epidemiologists waste 80% of their time cleaning data and
-              can't do useful analysis. The end goal of DIBBs infrastructure is
-              to free up that 80% of their time to do actual public health
-              work."
-            </p>
-            <p className="m-0 text-nowrap p-0 text-[1rem] font-light leading-[2rem] text-[#224a58] xl:m-4 xl:min-w-full xl:text-[1.38rem]">
-              - Public Health Official, Virginia Department of Health
-            </p>
-          </div>
-        </div>
+    <RoundedBackground className="p-10">
+      <div className="ml-2 flex flex-col gap-3 xl:min-w-[35.25rem]">
+        <p className="font-['Public Sans'] m-0 p-0 text-base font-light uppercase leading-normal text-[#2e6276]">
+          Customer Testimonial
+        </p>
+        <p className="font-['Public Sans'] m-0 max-w-[28rem] p-0 text-[1rem] font-bold italic leading-[2rem] text-[#224a58] lg:text-[1.38rem]">
+          "Our epidemiologists waste 80% of their time cleaning data and can't
+          do useful analysis. The end goal of DIBBs infrastructure is to free up
+          that 80% of their time to do actual public health work."
+        </p>
+        <p className="m-0 text-nowrap p-0 text-[1rem] font-light leading-[2rem] text-[#224a58] lg:text-base xl:min-w-full">
+          - Public Health Official, Virginia Department of Health
+        </p>
       </div>
-    </>
+    </RoundedBackground>
   );
 }
+
+const Alert = () => {
+  return (
+    <div className="usa-alert usa-alert--info usa-alert--no-icon border-l-[#00BDE3] lg:max-w-[80%]">
+      <div className="usa-alert__body !bg-[#2E6276]">
+        <p className="usa-alert__text font-['Public Sans'] text-[1.38rem] font-bold text-[#e7f2f5]">
+          All consultations with the DIBBs team are 100% free!
+        </p>
+        <p className="usa-alert__text font-['Public Sans'] text-base font-normal leading-snug text-[#e7f2f5]">
+          There's no cost to use our products beyond costs to host within your
+          jurisdiction should you choose to do so.
+        </p>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR updates the engage with us page to more closely match the design in Figma. I've also ensured the design is responsive (although this aspect may not be finalized until we review with UX).

Please check that:
- Style matches Figma
- Page works well on smaller display

![image](https://github.com/user-attachments/assets/e604e4f9-b0ad-47b2-9e34-485352d13b10)