### PR TITLE
Update header/footer nav to match design

### DIFF
--- a/src/app/components/Footer/Footer.tsx
+++ b/src/app/components/Footer/Footer.tsx
@@ -14,31 +14,16 @@ export default function Footer() {
   };
 
   const footerMenu = [
-    <NavigationLink key="one" href="/" onClick={onClick} showActive={false}>
+    <NavigationLink key="one" href="/" onClick={onClick}>
       Home
     </NavigationLink>,
-    <NavigationLink
-      key="two"
-      href="/products"
-      onClick={onClick}
-      showActive={false}
-    >
+    <NavigationLink key="two" href="/products" onClick={onClick}>
       Our products
     </NavigationLink>,
-    <NavigationLink
-      key="three"
-      href="/case-studies"
-      onClick={onClick}
-      showActive={false}
-    >
+    <NavigationLink key="three" href="/case-studies" onClick={onClick}>
       Case studies
     </NavigationLink>,
-    <NavigationLink
-      key="four"
-      href="/engage-with-us"
-      onClick={onClick}
-      showActive={false}
-    >
+    <NavigationLink key="four" href="/engage-with-us" onClick={onClick}>
       Engage with us
     </NavigationLink>,
   ];

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -42,7 +42,7 @@ export default function Header() {
   };
 
   const navigationLinks = navigationItems.map(({ key, href, text }) => (
-    <NavigationLink key={key} href={href} onClick={handleClick}>
+    <NavigationLink key={key} href={href} onClick={handleClick} isTopNav>
       {text}
     </NavigationLink>
   ));

--- a/src/app/components/NavigationLink/NavigationLink.tsx
+++ b/src/app/components/NavigationLink/NavigationLink.tsx
@@ -4,14 +4,14 @@ import { usePathname } from 'next/navigation';
 
 interface NavigationLinkProps extends Pick<LinkProps, 'href' | 'onClick'> {
   children: React.ReactNode;
-  showActive?: boolean;
+  isTopNav?: boolean;
 }
 
 export function NavigationLink({
   href,
   children,
   onClick,
-  showActive = true,
+  isTopNav = false,
 }: NavigationLinkProps) {
   const isActive = useIsActive(href);
 
@@ -24,9 +24,11 @@ export function NavigationLink({
     >
       <span
         className={classNames(
-          "lg:text-l font-['Public Sans'] font-bold leading-7 lg:text-white",
+          "font-['Public Sans'] font-bold leading-7 underline-offset-8 hover:underline lg:text-white",
           {
-            'underline underline-offset-8': isActive && showActive,
+            'underline decoration-[#82b4c9] underline-offset-8':
+              isActive && isTopNav,
+            'lg:text-xl': isTopNav,
           },
         )}
       >


### PR DESCRIPTION
This PR updates the header and footer nav's to match the Figma design. This should close out these issues in the [punch-list](https://docs.google.com/document/d/1HYsAwva0_VEj40uxqkBl2boglNTcG1_y3lbdsaIpJE4/edit):

- [ ] Nav links too small, should be H3 (20pt)
- [ ] Add hover and press state to nav text
  - [ ] Add underline to appear on hover
  - [ ] Tint 10% #000000 on hover, 20% on pressed
- [ ] Add finger cursor to clickable links/btns


Header:
![Kapture 2024-12-13 at 15 13 38](https://github.com/user-attachments/assets/4de81c0f-095f-4a0b-8e27-fd0e4519636b)

Footer:
![Kapture 2024-12-13 at 15 16 16](https://github.com/user-attachments/assets/358d228b-4095-479f-a1ae-29d2d17d2f71)