### PR TITLE
Fix USA banner text and padding

### DIFF
--- a/src/app/components/UsaBanner/UsaBanner.tsx
+++ b/src/app/components/UsaBanner/UsaBanner.tsx
@@ -20,12 +20,14 @@ export default function USABanner() {
   const dotGovIcon = `${basePath}/images/us-gov-icon.svg`;
   const httpsIcon = `${basePath}/images/https-icon.svg`;
 
+  const bannerLabel = 'An official website of the United States government';
   return (
-    <Banner aria-label="Official website of the state department of something specific">
+    <Banner aria-label={bannerLabel}>
       <BannerHeader
+        className="py-[.31rem]"
         isOpen={isOpen}
         flagImg={<BannerFlag src={flagImg} aria-hidden alt="" />}
-        headerText="This is an official website of the state department of something specific"
+        headerText={bannerLabel}
         headerActionText="Here's how you know"
       >
         <BannerButton


### PR DESCRIPTION
This PR addresses the following items in the [QA checklist](https://docs.google.com/document/d/1HYsAwva0_VEj40uxqkBl2boglNTcG1_y3lbdsaIpJE4/edit):
- [x] Fix top official website accordion language to match comps
  - [x] Add a touch of vertical padding to match comps 

Example:
<img width="461" alt="image" src="https://github.com/user-attachments/assets/61b0118b-89d5-4198-88a4-77d62dd8427c" />
