### PR TITLE
Lower font-weight value for Tailwind 'font-semibold'

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontWeight: {
+        semibold: '599',
+      },
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',


### PR DESCRIPTION
This PR lowers the font-weight of `font-semibold` from 600 to 599. It was noted in the [QA checklist](https://docs.google.com/document/d/1HYsAwva0_VEj40uxqkBl2boglNTcG1_y3lbdsaIpJE4/edit?tab=t.0#heading=h.xbdj3tqn9oml) that semibold font looks too bold.

600 does appear to be overly bold while dropping it to 599 looks more in-line with the Figma design.

Before:
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/74509c0f-c1c8-474e-8286-432ac4a1e4bb" />

After:
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/7086b493-277b-43c9-a961-52e59808fccf" />