### PR TITLE
Finalize the Query Connector demo section

### DIFF
--- a/src/app/components/LinkButton/LaunchIcon.tsx
+++ b/src/app/components/LinkButton/LaunchIcon.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { Icon } from '@trussworks/react-uswds';
+
+// Next can't render the USWDS icons server side, which is why this gets its own file
+export const LaunchIcon = () => {
+  return <Icon.Launch size={3} role="img" aria-label="Launch icon" />;
+};

--- a/src/app/components/LinkButton/LinkButton.tsx
+++ b/src/app/components/LinkButton/LinkButton.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import Link, { LinkProps } from 'next/link';
+import { LaunchIcon } from './LaunchIcon';
 
 const BUTTON_STYLES = {
   primary: {
@@ -22,6 +23,7 @@ interface LinkButtonProps extends LinkProps {
   className?: string;
   disabled?: boolean;
   'aria-label'?: string;
+  isExternal?: boolean;
 }
 
 export function LinkButton({
@@ -31,6 +33,7 @@ export function LinkButton({
   className = '',
   disabled = false,
   'aria-label': ariaLabel,
+  isExternal = false,
   ...props
 }: LinkButtonProps) {
   if (disabled) {
@@ -43,6 +46,24 @@ export function LinkButton({
       >
         <span className="font-bold text-black">{children}</span>
       </div>
+    );
+  }
+
+  if (isExternal) {
+    return (
+      <Link
+        href={href}
+        className={classNames(BUTTON_STYLES[variant].button, className)}
+        aria-label={ariaLabel}
+        target="_blank"
+        rel="noreferrer noopener"
+        {...props}
+      >
+        <span className="flex items-center gap-2 text-center font-bold text-inherit">
+          <span>{children}</span>
+          <LaunchIcon />
+        </span>
+      </Link>
     );
   }
 

--- a/src/app/products/query-connector/page.tsx
+++ b/src/app/products/query-connector/page.tsx
@@ -17,11 +17,10 @@ import {
   GettingStarted,
   HaveAQuestionSection,
   NavItem,
-  Figure,
 } from '../_ui';
 import Image from 'next/image';
 import { basePath } from '@/app/utils/constants';
-import { Link } from '@trussworks/react-uswds';
+import { LinkButton } from '@/app/components/LinkButton/LinkButton';
 
 export default function QueryConnector() {
   const navItems: NavItem[] = [
@@ -118,22 +117,19 @@ pull relevant data from a wide network of healthcare providers."
                   <div>
                     <SubsectionContainer>
                       <SectionSubheader>Demo</SectionSubheader>
-                      <Link
-                        variant="external"
-                        href="https://dibbs.cloud/query-connector"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        Query Connector demo
-                      </Link>
-                      <Figure caption="See how the Query Connector can improve the way your jurisdiction searches for data.">
-                        <Image
-                          alt="Query Connector demo site"
-                          width={652}
-                          height={383}
-                          src={`${basePath}/images/products/query-connector/demo-site.png`}
-                        />
-                      </Figure>
+                      <Text>
+                        See how the Query Connector can improve the way your
+                        jurisdiction searches for data:
+                      </Text>
+                      <div>
+                        <LinkButton
+                          isExternal
+                          variant="primary"
+                          href="https://dibbs.cloud/query-connector"
+                        >
+                          Launch demo
+                        </LinkButton>
+                      </div>
                     </SubsectionContainer>
                   </div>
                 </SectionContentContainer>


### PR DESCRIPTION
This PR finalizes the Query Connector product detail page's Demo section content based on the Figma design.

Here is what it looks like on the page:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/7d3f2243-9e15-4086-a1ab-b27d38d18822" />