### PR TITLE
Add "become a pilot partner" button to Query Connector page

### DIFF
--- a/src/app/products/_ui/index.tsx
+++ b/src/app/products/_ui/index.tsx
@@ -279,7 +279,7 @@ const ValueList = ({ children }: ContainerProps) => {
 
 const ContentContainer = ({ children }: ContainerProps) => {
   return (
-    <div className="ml-auto mr-auto flex max-w-[87.5rem] flex-col px-2 lg:pb-[5rem] xl:px-[7.5rem]">
+    <div className="ml-auto mr-auto flex max-w-[87.5rem] flex-col px-2 lg:pb-[5rem] xl:px-[3.5rem]">
       {children}
     </div>
   );

--- a/src/app/products/query-connector/page.tsx
+++ b/src/app/products/query-connector/page.tsx
@@ -189,7 +189,6 @@ pull relevant data from a wide network of healthcare providers."
                       process by returning a FHIR bundle that your IT team could
                       integrate directly into your data surveillance system.
                     </span>
-
                     <span>
                       For instance, if your jurisdiction wants to query back to
                       a healthcare provider every time you receive a lab for an
@@ -205,19 +204,26 @@ pull relevant data from a wide network of healthcare providers."
               <SectionContentContainer>
                 <SubsectionContainer>
                   <SectionHeader>Development status</SectionHeader>
-                  <Text className="flex flex-col gap-6">
-                    <span>
-                      We're currently testing the Query Connector with a small
-                      group of pilot jurisdictions and are continuing to tweak
-                      it and add new features.
-                    </span>
-                    <span>
-                      Once these pilots are complete, we're hoping to open up
-                      the Query Connector to a broader user audience with robust
-                      documentation about how to implement the product in
-                      different technical setups.
-                    </span>
-                  </Text>
+                  <div className='flex flex-col gap-5'>
+                    <Text className="flex flex-col gap-6">
+                      <span>
+                        We're currently testing the Query Connector with a small
+                        group of pilot jurisdictions and are continuing to tweak
+                        it and add new features.
+                      </span>
+                      <span>
+                        Once these pilots are complete, we're hoping to open up
+                        the Query Connector to a broader user audience with
+                        robust documentation about how to implement the product
+                        in different technical setups.
+                      </span>
+                    </Text>
+                    <div>
+                      <LinkButton href="/engage-with-us" variant="primary">
+                        Become a pilot partner
+                      </LinkButton>
+                    </div>
+                  </div>
                 </SubsectionContainer>
               </SectionContentContainer>
             </section>

--- a/src/app/products/query-connector/page.tsx
+++ b/src/app/products/query-connector/page.tsx
@@ -183,15 +183,20 @@ pull relevant data from a wide network of healthcare providers."
                 </SubsectionContainer>
                 <SubsectionContainer>
                   <SectionSubheader>Automated data connection</SectionSubheader>
-                  <Text>
-                    The Query Connector's API allows your jurisdiction to
-                    automate the querying process and then integrate returned
-                    data directly into your data surveillance system. For
-                    instance, if your jurisdiction wants to query back to a
-                    healthcare provider every time you receive a lab for an STI,
-                    our API would allow you to automate that process,
-                    eliminating the need for a staff member to manually make
-                    each query.
+                  <Text className="flex flex-col gap-6">
+                    <span>
+                      The Query Connector's API can automate the querying
+                      process by returning a FHIR bundle that your IT team could
+                      integrate directly into your data surveillance system.
+                    </span>
+
+                    <span>
+                      For instance, if your jurisdiction wants to query back to
+                      a healthcare provider every time you receive a lab for an
+                      STI, our API would allow your to automate that process,
+                      eliminating the need for a staff member to manually make
+                      each query.
+                    </span>
                   </Text>
                 </SubsectionContainer>
               </SectionContentContainer>


### PR DESCRIPTION
This PR adds the `Become a pilot partner` link button to the Query Connector product detail page. This link button will link users to the `/engage-with-us` form. I've also cleaned up the [`Development status`](https://www.figma.com/design/3VaLNvirF5Tq2RFHsD32g1/dibbs.cdc.gov?node-id=2432-2857&m=dev) section content.