### PR TITLE
Fix footer logo not loading in correctly

### DIFF
--- a/src/app/components/Footer/Footer.tsx
+++ b/src/app/components/Footer/Footer.tsx
@@ -45,7 +45,7 @@ export default function Footer() {
                     height={64}
                     alt="Centers for Disease Control and Prevention"
                     layout="intrinsic" // preserve aspect ratio when screen size changes
-                    src={`${basePath}/images/cdc.svg`}
+                    src={`${basePath}/images/CDC.svg`}
                   />
                 </a>
               </em>


### PR DESCRIPTION
This PR addresses an issue where the CDC logo would not display correctly in a live (prod build) environment.