### PR TITLE
Add link buttons to engage with us page at bottom of product detail pages

### DIFF
--- a/src/app/products/_ui/index.tsx
+++ b/src/app/products/_ui/index.tsx
@@ -8,18 +8,19 @@ import {
 import classNames from 'classnames';
 import './styles.scss';
 import Image, { ImageProps } from 'next/image';
+import { LinkButton } from '@/app/components/LinkButton/LinkButton';
 
 interface ContainerProps {
   children: React.ReactNode;
 }
 
-const SendMailLink = () => {
+const SendMailLink = ({ text }: { text: string }) => {
   return (
     <Link
       className="font-bold leading-snug underline-offset-4"
-      href="mailto:dibbs@cdc.gov"
+      href="/engage-with-us"
     >
-      dibbs@cdc.gov
+      {text}
     </Link>
   );
 };
@@ -122,9 +123,13 @@ const HaveAQuestionSection = () => {
   return (
     <div className="flex flex-col gap-3 pt-5">
       <h2>Have a question that isn't answered above?</h2>
-      <Text className="font-bold">
-        Please get in touch with our team at <SendMailLink />
-      </Text>
+      <LinkButton
+        className="place-self-start"
+        variant="primary"
+        href="/engage-with-us"
+      >
+        Get in touch with our team
+      </LinkButton>
     </div>
   );
 };

--- a/src/app/products/ecr-viewer/page.tsx
+++ b/src/app/products/ecr-viewer/page.tsx
@@ -363,8 +363,8 @@ export default function EcrViewer() {
                             <span>
                               We are also working on a direct integration with
                               EpiTrax. If you're interested in integrating the
-                              eCR Viewer with other surveillance systems, please
-                              reach out to us at <SendMailLink />.
+                              eCR Viewer with other surveillance systems, please{' '}
+                              <SendMailLink text="reach out to us" />.
                             </span>
                           </div>
                         </AccordionItemContent>
@@ -485,9 +485,9 @@ export default function EcrViewer() {
                       title: 'How do I get started?',
                       content: (
                         <AccordionItemContent>
-                          Reach out to our team at <SendMailLink /> for a free
-                          consultation and find our whether the eCR Viewer is
-                          right for your jurisdiction.
+                          Please <SendMailLink text="contact our team" /> for a
+                          free consultation and find our whether the eCR Viewer
+                          is right for your jurisdiction.
                         </AccordionItemContent>
                       ),
                     },


### PR DESCRIPTION
This PR updates the `Have a question that isn't answered above?` section of the product detail pages to include a `LinkButton` that navigates the user to the `engage with us` page.

It also adds links to the `engage with us` page from eCR Viewer's FAQ accordion items.