### PR TITLE
Page title meta tags should include DIBBs branding

### DIFF
--- a/src/app/case-studies/_cloud-hosting/page.tsx
+++ b/src/app/case-studies/_cloud-hosting/page.tsx
@@ -13,7 +13,7 @@ import { Metadata } from 'next';
 import cloudHostingImg from '/public/images/case-studies/cloud-hosting/image1.png';
 
 export const metadata: Metadata = {
-  title: 'Cloud Hosting',
+  title: 'Cloud Hosting - DIBBs',
   description:
     'Improving public health data infrastructure through flexible, modern approaches to cloud services',
 };

--- a/src/app/case-studies/_ecr-viewer/page.tsx
+++ b/src/app/case-studies/_ecr-viewer/page.tsx
@@ -13,7 +13,7 @@ import { Metadata } from 'next';
 import ecrViewerImg from '/public/images/case-studies/ecr-viewer/image1.png';
 
 export const metadata: Metadata = {
-  title: 'eCR Viewer',
+  title: 'eCR Viewer - DIBBs',
   description:
     'Surfacing actionable insights from electronic case reporting data.',
 };

--- a/src/app/case-studies/dibbs-pipeline/page.tsx
+++ b/src/app/case-studies/dibbs-pipeline/page.tsx
@@ -14,7 +14,7 @@ import {
 import dibbsPipelineImg from '/public/images/case-studies/dibbs-pipeline/image1.png';
 
 export const metadata: Metadata = {
-  title: 'DIBBs Pipeline',
+  title: 'DIBBs Pipeline - DIBBs',
   description:
     'Creating a modular, cloud-based data processing pipeline for LA County.',
 };

--- a/src/app/case-studies/dibbs-prototype/page.tsx
+++ b/src/app/case-studies/dibbs-prototype/page.tsx
@@ -14,7 +14,7 @@ import { Metadata } from 'next';
 import dibbsPrototypeImg from '/public/images/case-studies/dibbs-prototype/image1.png';
 
 export const metadata: Metadata = {
-  title: 'DIBBs Prototype',
+  title: 'DIBBs Prototype - DIBBs',
   description:
     'Building a prototype for modernized public health infrastructure in Virginia.',
 };

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -8,7 +8,7 @@ import laCountyImg from '/public/images/case-studies/image1.jpg';
 import vaImg from '/public/images/case-studies/image4.jpg';
 
 export const metadata: Metadata = {
-  title: 'Case Studies',
+  title: 'Case Studies - DIBBs',
   description: 'Explore our case studies to see the impact of DIBBs.',
 };
 

--- a/src/app/engage-with-us/page.tsx
+++ b/src/app/engage-with-us/page.tsx
@@ -5,7 +5,7 @@ import { Metadata } from 'next';
 import './styles.scss';
 
 export const metadata: Metadata = {
-  title: 'Engage with us',
+  title: 'Engage with us - DIBBs',
   description:
     'Learn how your jurisdiction can start working with the DIBBs team.',
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import valueTout from '/public/images/home/value-tout.jpg';
 import introTout from '/public/images/home/intro-tout.jpg';
 
 export const metadata: Metadata = {
-  title: 'Home',
+  title: 'Home - DIBBs',
   description:
     "Turn your jurisdiction's data into meaningful intelligence that drives timely public health action using CDC's free, cloud-based products built from Data Integration Building Blocks, or DIBBs.",
 };

--- a/src/app/products/ecr-viewer/page.tsx
+++ b/src/app/products/ecr-viewer/page.tsx
@@ -26,7 +26,7 @@ import howItWorksGif from '/public/images/products/ecr-viewer/how-it-works.gif';
 import nonIntegratedImg from '/public/images/products/ecr-viewer/non-integrated.png';
 
 export const metadata: Metadata = {
-  title: 'eCR Viewer',
+  title: 'eCR Viewer - DIBBs',
   description:
     'An intuitive interface that helps epidemiologists and case investigators make better sense of eCR data, faster.',
 };

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -19,7 +19,7 @@ import flatFormatterIcon from '/public/icons/products/flatFormatter.svg';
 import phdcConverterIcon from '/public/icons/products/phdcConverter.svg';
 
 export const metadata: Metadata = {
-  title: 'Our Products',
+  title: 'Our Products - DIBBs',
   description:
     'Find out how DIBBs products can help empower your jurisdiction with more usable data.',
 };

--- a/src/app/products/query-connector/page.tsx
+++ b/src/app/products/query-connector/page.tsx
@@ -23,7 +23,7 @@ import surfacePatientDataImg from '/public/images/products/query-connector/surfa
 import customQueryImg from '/public/images/products/query-connector/custom-query.png';
 
 export const metadata: Metadata = {
-  title: 'Query Connector',
+  title: 'Query Connector - DIBBs',
   description:
     'A data collection tool that helps public health staff pull relevant data from a wide network of healthcare providers.',
 };


### PR DESCRIPTION
This PR updates all page title meta tags to include `- DIBBs` at the end. This should help make the purpose of the site and its pages much more obvious.