### PR TITLE
bump action/upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./out
       - name: Audit URLs using Lighthouse


### PR DESCRIPTION
Bumping our version for this action to v4 as previous versions have been deprecated which is causing other workflows to fail.